### PR TITLE
Update for aprsd-manager compatibility

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,16 @@
 CHANGES
 =======
 
+1.2.9
+-----
+
+* testing for aprsd-manager
+
+1.3.1
+-----
+
+* Update README and documentation
+
 1.3.0
 -----
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,9 +149,6 @@ aprsd-repeat-plugins-export-config = "aprsd_repeat_plugins.cli:main"
 [project.entry-points."oslo.config.opts"]
     "aprsd_repeat_plugins.conf" = "aprsd_repeat_plugins.conf.opts:list_opts"
 
-[project.entry-points."oslo.config.opts.defaults"]
-    "aprsd_repeat_plugins.conf" = "aprsd_repeat_plugins.conf:set_lib_defaults"
-
 # If you are using a different build backend, you will need to change this.
 [tool.setuptools]
 # If there are data files included in your packages that need to be
@@ -162,7 +159,7 @@ packages = ["aprsd_repeat_plugins"]
 
 [build-system]
 requires = [
-    "setuptools>=69.5.0",
+    "setuptools>=80.0.0",
     "setuptools_scm>=0",
     "wheel",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,6 @@ classifiers = [
 # For an analysis of this field vs pip's requirements files see:
 # https://packaging.python.org/discussions/install-requires-vs-requirements/
 dependencies = [
-    "aprsd>=4.0.0",
     "requests",
     "oslo-config",
     "pyproj",


### PR DESCRIPTION
## Summary
- Remove `aprsd>=4.0.0` dependency to allow use with aprsd-manager
- Remove `oslo.config.opts.defaults` entry point (removed `set_lib_defaults`)
- Update `setuptools` requirement to `>=80.0.0`
- Add ChangeLog entries for versions 1.2.9 and 1.3.1

## Summary by Sourcery

Relax aprsd integration requirements and update build metadata for compatibility with newer tooling.

Enhancements:
- Remove the hard dependency on aprsd to allow use in environments such as aprsd-manager.
- Drop the obsolete oslo.config default options entry point that is no longer needed.

Build:
- Raise the setuptools build requirement to version 80.0.0 or newer.

Documentation:
- Add ChangeLog entries documenting releases 1.2.9 and 1.3.1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build system dependencies
  * Removed external dependency

* **Documentation**
  * Added ChangeLog entries for versions 1.2.9 and 1.3.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->