### PR TITLE
Show actual offset value in NearestPlugin response

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,38 +122,53 @@ n[earest] [count] [band] [+filter]
 **Basic usage - find nearest repeater:**
 ```
 You: n
-APRSD: W6ABC 146.520+ T88.5 2.3mi NE
+APRSD: W6ABC 146.940 -.6 T88.5 2.3mi NE
 ```
 
 **Find 3 nearest repeaters:**
 ```
 You: n 3
-APRSD: W6ABC 146.520+ T88.5 2.3mi NE
-      W6XYZ 147.330+ T100.0 5.1mi SW
-      W6DEF 145.230- T103.5 8.7mi N
+APRSD: W6ABC 146.940 -.6 T88.5 2.3mi NE
+      W6XYZ 147.330 +.6 T100.0 5.1mi SW
+      W6DEF 145.230 -.6 T103.5 8.7mi N
 ```
 
 **Find nearest 70cm repeater:**
 ```
 You: n 70cm
-APRSD: W6ABC 446.000+ T88.5 1.2mi SE
+APRSD: W6ABC 446.000 -5 T88.5 1.2mi SE
 ```
 
 **Find nearest EchoLink-enabled repeater:**
 ```
 You: n +echo
-APRSD: W6ABC 146.520+ T88.5 3.4mi NE
+APRSD: W6ABC 146.940 -.6 T88.5 3.4mi NE
 ```
 
 **Find 5 nearest 2m DMR repeaters:**
 ```
 You: n 5 2m +dmr
-APRSD: W6ABC 146.520+ T88.5 2.3mi NE
-      W6XYZ 147.330+ T100.0 5.1mi SW
-      W6DEF 145.230- T103.5 8.7mi N
-      W6GHI 147.450+ T103.5 12.4mi E
-      W6JKL 146.640- T88.5 15.8mi W
+APRSD: W6ABC 146.940 -.6 T88.5 2.3mi NE
+      W6XYZ 147.330 +.6 T100.0 5.1mi SW
+      W6DEF 145.230 -.6 T103.5 8.7mi N
+      W6GHI 147.450 +.6 T103.5 12.4mi E
+      W6JKL 146.640 -.6 T88.5 15.8mi W
 ```
+
+#### Offset Examples
+
+The offset field shows the actual frequency offset in MHz, which is especially useful for
+non-standard repeater configurations:
+
+| Band | Offset | Description |
+|------|--------|-------------|
+| 2m | `-.6` | Standard negative 600 kHz offset |
+| 2m | `+.6` | Standard positive 600 kHz offset |
+| 2m | `-2.5` | Non-standard 2.5 MHz offset (some regions) |
+| 70cm | `-5` | Standard negative 5 MHz offset |
+| 70cm | `+5` | Standard positive 5 MHz offset |
+| 70cm | `-7.6` | Non-standard 7.6 MHz offset (common in some areas) |
+| Any | `0` | Simplex (no offset) |
 
 #### Supported Frequency Bands
 
@@ -241,22 +256,28 @@ APRSD: APRS REPEAT Version: 1.0.0
 The `NearestPlugin` returns responses in the following format:
 
 ```
-<CALLSIGN> <FREQUENCY><OFFSET> <TONE> <DISTANCE><UNITS> <DIRECTION>
+<CALLSIGN> <FREQUENCY> <OFFSET> <TONE> <DISTANCE><UNITS> <DIRECTION>
 ```
 
 Where:
 - `CALLSIGN`: Repeater callsign
-- `FREQUENCY`: Repeater frequency (e.g., `146.520`)
-- `OFFSET`: Offset direction (`+` for positive, `-` for negative)
-- `TONE`: CTCSS tone (e.g., `T88.5`)
+- `FREQUENCY`: Repeater output frequency in MHz (e.g., `146.940`)
+- `OFFSET`: Offset in MHz with sign (e.g., `-.6`, `+5`, `-7.6`, `0` for simplex)
+- `TONE`: CTCSS/PL tone required for access (e.g., `T88.5`, `Toff` if none)
 - `DISTANCE`: Distance in miles (US/UK) or kilometers (elsewhere)
 - `UNITS`: Distance units (`mi` or `km`)
-- `DIRECTION`: Compass direction (N, NE, E, SE, S, SW, W, NW)
+- `DIRECTION`: Compass direction from your location (N, NE, E, SE, S, SW, W, NW)
 
 Example:
 ```
-W6ABC 146.520+ T88.5 2.3mi NE
+W6ABC 146.940 -.6 T88.5 2.3mi NE
 ```
+
+**Why show the actual offset?** While many repeaters use standard offsets (±600 kHz for 2m,
+±5 MHz for 70cm), a significant number use non-standard offsets. For example, approximately
+28% of 70cm repeaters in the database use offsets other than ±5 MHz (such as -7.6 MHz or
+-9 MHz). Showing the actual offset ensures you can correctly program your radio regardless
+of local frequency coordination practices.
 
 ## Troubleshooting
 

--- a/aprsd_repeat_plugins/nearest.py
+++ b/aprsd_repeat_plugins/nearest.py
@@ -179,6 +179,13 @@ class NearestPlugin(
     def _format_offset_mhz(self, offset):
         """Format offset in MHz with sign, removing trailing zeros.
 
+        Args:
+            offset: Offset value (float, int, string, or None)
+
+        Returns:
+            Formatted offset string (e.g., '-.6', '+5', '-7.6', '0')
+            Returns empty string if offset is None or invalid.
+
         Examples:
             0 -> '0'
             -0.6 -> '-.6'
@@ -186,8 +193,15 @@ class NearestPlugin(
             -5.0 -> '-5'
             +5.0 -> '+5'
             -7.6 -> '-7.6'
+            None -> ''
+            'invalid' -> ''
         """
-        offset = float(offset)
+        if offset is None:
+            return ''
+        try:
+            offset = float(offset)
+        except (ValueError, TypeError):
+            return ''
         if offset == 0:
             return '0'
         # Format with up to 1 decimal place, strip unnecessary zeros
@@ -323,10 +337,8 @@ class NearestPlugin(
             for entry in data:
                 LOG.info(f'Using {entry}')
 
-                if 'offset' not in entry:
-                    offset_str = ''
-                else:
-                    offset_str = self._format_offset_mhz(entry['offset'])
+                # Format offset - handles None, missing keys, and invalid values
+                offset_str = self._format_offset_mhz(entry.get('offset'))
 
                 # US and UK are in miles, everywhere else is metric?
                 # by default units are meters
@@ -347,10 +359,15 @@ class NearestPlugin(
 
                 uplink_offset = self._tone(entry['uplink_offset'], human=True)
 
-                reply = '{} {} {} {} {}{} {}'.format(
+                # Build reply, avoiding double spaces if offset is empty
+                freq_offset = (
+                    f'{entry["frequency"]} {offset_str}'
+                    if offset_str
+                    else str(entry['frequency'])
+                )
+                reply = '{} {} {} {}{} {}'.format(
                     entry['callsign'],
-                    entry['frequency'],
-                    offset_str,
+                    freq_offset,
                     uplink_offset,
                     distance,
                     units,

--- a/aprsd_repeat_plugins/nearest.py
+++ b/aprsd_repeat_plugins/nearest.py
@@ -176,6 +176,26 @@ class NearestPlugin(
             offset = f'+{offset:.2f}'
         return '{}'.format(offset.replace('.', ''))
 
+    def _format_offset_mhz(self, offset):
+        """Format offset in MHz with sign, removing trailing zeros.
+
+        Examples:
+            0 -> '0'
+            -0.6 -> '-.6'
+            +0.6 -> '+.6'
+            -5.0 -> '-5'
+            +5.0 -> '+5'
+            -7.6 -> '-7.6'
+        """
+        offset = float(offset)
+        if offset == 0:
+            return '0'
+        # Format with up to 1 decimal place, strip unnecessary zeros
+        formatted = f'{offset:+.1f}'.rstrip('0').rstrip('.')
+        # Remove leading zero before decimal (e.g., +0.6 -> +.6)
+        formatted = formatted.replace('+0.', '+.').replace('-0.', '-.')
+        return formatted
+
     def setup(self):
         self.ensure_aprs_fi_key()
         if not CONF.aprsd_repeat_plugins.haminfo_apiKey:
@@ -304,11 +324,9 @@ class NearestPlugin(
                 LOG.info(f'Using {entry}')
 
                 if 'offset' not in entry:
-                    offset_direction = ''
-                elif self.isfloat(entry['offset']) and float(entry['offset']) > 0:
-                    offset_direction = '+'
+                    offset_str = ''
                 else:
-                    offset_direction = '-'
+                    offset_str = self._format_offset_mhz(entry['offset'])
 
                 # US and UK are in miles, everywhere else is metric?
                 # by default units are meters
@@ -329,10 +347,10 @@ class NearestPlugin(
 
                 uplink_offset = self._tone(entry['uplink_offset'], human=True)
 
-                reply = '{} {}{} {} {}{} {}'.format(
+                reply = '{} {} {} {} {}{} {}'.format(
                     entry['callsign'],
                     entry['frequency'],
-                    offset_direction,
+                    offset_str,
                     uplink_offset,
                     distance,
                     units,


### PR DESCRIPTION
## Summary

- Display the actual frequency offset in MHz (e.g., `-.6`, `+5`, `-7.6`) instead of just `+` or `-`
- Add documentation explaining offset formats and why showing actual values matters

## Problem

Previously, the NearestPlugin only showed offset direction (`+` or `-`), which assumed users knew the standard offset for each band. However, analysis of the production database revealed:

- **~28% of 70cm repeaters** use non-standard offsets (e.g., -7.6 MHz, -9 MHz instead of ±5 MHz)
- **~2.5% of 2m repeaters** use non-standard offsets (e.g., -2.5 MHz instead of ±600 kHz)
- **~1,000+ simplex repeaters** have zero offset

Users could easily program incorrect offsets for these non-standard repeaters.

## Solution

Now the response includes the actual offset value:

| Before | After |
|--------|-------|
| `W6ABC 146.940+ T88.5 2.3mi NE` | `W6ABC 146.940 -.6 T88.5 2.3mi NE` |
| `W6ABC 446.000- T88.5 1.2mi SE` | `W6ABC 446.000 -5 T88.5 1.2mi SE` |
| (non-standard) `W6ABC 446.000- T88.5` | `W6ABC 446.000 -7.6 T88.5 1.2mi SE` |

## Changes

- Added `_format_offset_mhz()` helper method in `nearest.py`
- Updated `NearestPlugin.process()` to use actual offset values
- Updated README with new format examples and offset reference table

## Summary by Sourcery

Display actual repeater frequency offsets in NearestPlugin responses and document the new offset format and rationale.

New Features:
- Show the actual offset value in MHz (with sign) in NearestPlugin output instead of only the offset direction.

Enhancements:
- Add a helper to format offsets in MHz for consistent, human-friendly display across repeaters.

Documentation:
- Update README examples and add an offset reference section explaining the new offset display format and why exact values are shown.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated NearestPlugin docs and examples to show OFFSET as a signed MHz value (e.g., `146.940 -.6`, `446.000 -5`), added an "Offset Examples" section, clarified field ordering and definitions, expanded tone description (shows `Toff` when none), and explained direction as relative to user location.

* **Improvements**
  * Responses now output frequency and signed offset as separate fields, omit invalid/empty offsets (simplex `0` shown), and avoid extra spacing in formatted replies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->