### PR TITLE
feat: Add tiered help system for REPEAT plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,44 @@ You: v
 APRSD: APRS REPEAT Version: 1.0.0
 ```
 
+### Help System
+
+The REPEAT plugins include a tiered help system to provide concise or detailed
+help over APRS without flooding the network.
+
+#### Basic Help
+
+Send `help <plugin>` for a quick syntax reference (1-2 messages):
+
+```
+help nearest
+help object
+help version
+```
+
+#### Detailed Help
+
+Send `help <plugin> full` for complete documentation (4-8 messages):
+
+```
+help nearest full
+help object full
+```
+
+#### RepeatHelpPlugin Configuration
+
+To use the REPEAT help system, enable `RepeatHelpPlugin` and disable APRSD's
+built-in HelpPlugin:
+
+```yaml
+aprsd:
+  enabled_plugins:
+    - aprsd_repeat_plugins.help.RepeatHelpPlugin
+    - aprsd_repeat_plugins.nearest.NearestPlugin
+    - aprsd_repeat_plugins.nearest.NearestObjectPlugin
+    - aprsd_repeat_plugins.version.VersionPlugin
+```
+
 ## Response Format
 
 The `NearestPlugin` returns responses in the following format:

--- a/aprsd_repeat_plugins/help.py
+++ b/aprsd_repeat_plugins/help.py
@@ -1,0 +1,62 @@
+"""Tiered help system for APRSD REPEAT plugins."""
+
+import abc
+import logging
+
+LOG = logging.getLogger('APRSD')
+
+MAX_APRS_MSG_LEN = 67
+
+
+class TieredHelpMixin(abc.ABC):
+    """Mixin providing tiered help for APRS plugins.
+
+    Plugins inherit from this mixin and implement help_basic() and help_full().
+    The help() method returns help_basic() for backward compatibility with
+    APRSD's built-in HelpPlugin.
+    """
+
+    @abc.abstractmethod
+    def help_basic(self) -> list[str]:
+        """Return 1-2 short messages with syntax and options preview.
+
+        Returns:
+            List of help message strings, each <=67 chars for APRS.
+        """
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def help_full(self) -> list[str]:
+        """Return complete reference with all bands, filters, and examples.
+
+        Returns:
+            List of help message strings, each <=67 chars for APRS.
+        """
+        raise NotImplementedError
+
+    def help(self) -> list[str]:
+        """Return basic help for backward compatibility.
+
+        This is called by APRSD's built-in HelpPlugin.
+
+        Returns:
+            Result of help_basic().
+        """
+        return self.help_basic()
+
+    def _validate_help_messages(self, messages: list[str]) -> list[str]:
+        """Log warning if any message exceeds APRS limit.
+
+        Args:
+            messages: List of help message strings.
+
+        Returns:
+            The same list of messages (for chaining).
+        """
+        for msg in messages:
+            if len(msg) > MAX_APRS_MSG_LEN:
+                LOG.warning(
+                    f'Help message exceeds {MAX_APRS_MSG_LEN} chars '
+                    f'({len(msg)}): {msg}',
+                )
+        return messages

--- a/aprsd_repeat_plugins/help.py
+++ b/aprsd_repeat_plugins/help.py
@@ -3,6 +3,10 @@
 import abc
 import logging
 
+from aprsd import plugin
+
+import aprsd_repeat_plugins
+
 LOG = logging.getLogger('APRSD')
 
 MAX_APRS_MSG_LEN = 67
@@ -60,3 +64,113 @@ class TieredHelpMixin(abc.ABC):
                     f'({len(msg)}): {msg}',
                 )
         return messages
+
+
+class RepeatHelpPlugin(TieredHelpMixin, plugin.APRSDRegexCommandPluginBase):
+    """Help plugin for APRSD REPEAT service.
+
+    Replaces APRSD's built-in HelpPlugin with tiered help support.
+    Handles:
+    - help (list available plugins)
+    - help <plugin> (basic help for plugin)
+    - help <plugin> full (detailed help for plugin)
+    """
+
+    version = aprsd_repeat_plugins.__version__
+    command_regex = r'^[hH](elp)?'
+    command_name = 'help'
+
+    def help_basic(self) -> list[str]:
+        return ['help <plugin> or help <plugin> full']
+
+    def help_full(self) -> list[str]:
+        return [
+            'help - list available plugins',
+            'help <plugin> - basic help for plugin',
+            'help <plugin> full - detailed help',
+        ]
+
+    def setup(self):
+        """Plugin setup."""
+        self.enabled = True
+
+    def _parse_help_message(self, message: str) -> tuple[str, str | None, bool]:
+        """Parse help message to extract command, plugin name, and full flag.
+
+        Args:
+            message: The message text (e.g., "help nearest full")
+
+        Returns:
+            Tuple of (command, plugin_name or None, is_full bool)
+        """
+        parts = message.strip().lower().split()
+        cmd = parts[0] if parts else ''
+        plugin_name = None
+        is_full = False
+
+        if len(parts) >= 2:
+            plugin_name = parts[1]
+        if len(parts) >= 3 and parts[2] == 'full':
+            is_full = True
+
+        return cmd, plugin_name, is_full
+
+    def _get_repeat_plugins(self) -> dict:
+        """Get all enabled REPEAT plugins that have TieredHelpMixin.
+
+        Returns:
+            Dict mapping command_name to plugin instance.
+        """
+        from aprsd.plugin import PluginManager
+
+        pm = PluginManager()
+        plugins = {}
+
+        for p in pm.get_plugins():
+            if (
+                p.enabled
+                and hasattr(p, 'command_name')
+                and isinstance(p, TieredHelpMixin)
+                and p.command_name != 'help'  # Exclude self
+            ):
+                plugins[p.command_name.lower()] = p
+
+        return plugins
+
+    def process(self, packet):
+        """Process help command.
+
+        Args:
+            packet: APRS message packet.
+
+        Returns:
+            Help response string or list of strings.
+        """
+        LOG.info('RepeatHelpPlugin')
+
+        message = packet.message_text
+        _, plugin_name, is_full = self._parse_help_message(message)
+
+        # Get available REPEAT plugins
+        plugins = self._get_repeat_plugins()
+
+        if plugin_name is None:
+            # User sent just "help" - list available plugins
+            plugin_names = sorted(plugins.keys())
+            if plugin_names:
+                return [
+                    "Send 'help <plugin>' or 'help <plugin> full'",
+                    f'plugins: {" ".join(plugin_names)}',
+                ]
+            return 'No plugins available'
+
+        # User wants help for a specific plugin
+        if plugin_name in plugins:
+            p = plugins[plugin_name]
+            if is_full:
+                return p.help_full()
+            return p.help_basic()
+
+        # Unknown plugin
+        available = ', '.join(sorted(plugins.keys()))
+        return f"Unknown plugin '{plugin_name}'. Available: {available}"

--- a/aprsd_repeat_plugins/help.py
+++ b/aprsd_repeat_plugins/help.py
@@ -44,9 +44,9 @@ class TieredHelpMixin(abc.ABC):
         This is called by APRSD's built-in HelpPlugin.
 
         Returns:
-            Result of help_basic().
+            Result of help_basic(), validated for message length.
         """
-        return self.help_basic()
+        return self._validate_help_messages(self.help_basic())
 
     def _validate_help_messages(self, messages: list[str]) -> list[str]:
         """Log warning if any message exceeds APRS limit.
@@ -94,17 +94,16 @@ class RepeatHelpPlugin(TieredHelpMixin, plugin.APRSDRegexCommandPluginBase):
         """Plugin setup."""
         self.enabled = True
 
-    def _parse_help_message(self, message: str) -> tuple[str, str | None, bool]:
-        """Parse help message to extract command, plugin name, and full flag.
+    def _parse_help_message(self, message: str) -> tuple[str | None, bool]:
+        """Parse help message to extract plugin name and full flag.
 
         Args:
             message: The message text (e.g., "help nearest full")
 
         Returns:
-            Tuple of (command, plugin_name or None, is_full bool)
+            Tuple of (plugin_name or None, is_full bool)
         """
         parts = message.strip().lower().split()
-        cmd = parts[0] if parts else ''
         plugin_name = None
         is_full = False
 
@@ -113,7 +112,7 @@ class RepeatHelpPlugin(TieredHelpMixin, plugin.APRSDRegexCommandPluginBase):
         if len(parts) >= 3 and parts[2] == 'full':
             is_full = True
 
-        return cmd, plugin_name, is_full
+        return plugin_name, is_full
 
     def _get_repeat_plugins(self) -> dict:
         """Get all enabled REPEAT plugins that have TieredHelpMixin.
@@ -149,7 +148,7 @@ class RepeatHelpPlugin(TieredHelpMixin, plugin.APRSDRegexCommandPluginBase):
         LOG.info('RepeatHelpPlugin')
 
         message = packet.message_text
-        _, plugin_name, is_full = self._parse_help_message(message)
+        plugin_name, is_full = self._parse_help_message(message)
 
         # Get available REPEAT plugins
         plugins = self._get_repeat_plugins()
@@ -168,9 +167,11 @@ class RepeatHelpPlugin(TieredHelpMixin, plugin.APRSDRegexCommandPluginBase):
         if plugin_name in plugins:
             p = plugins[plugin_name]
             if is_full:
-                return p.help_full()
-            return p.help_basic()
+                return self._validate_help_messages(p.help_full())
+            return self._validate_help_messages(p.help_basic())
 
-        # Unknown plugin
-        available = ', '.join(sorted(plugins.keys()))
-        return f"Unknown plugin '{plugin_name}'. Available: {available}"
+        # Unknown plugin - handle empty plugins case
+        if plugins:
+            available = ', '.join(sorted(plugins.keys()))
+            return f"Unknown plugin '{plugin_name}'. Available: {available}"
+        return f"Unknown plugin '{plugin_name}'. No plugins available"

--- a/aprsd_repeat_plugins/nearest.py
+++ b/aprsd_repeat_plugins/nearest.py
@@ -11,6 +11,7 @@ from oslo_config import cfg
 
 import aprsd_repeat_plugins
 from aprsd_repeat_plugins import conf  # noqa
+from aprsd_repeat_plugins.help import TieredHelpMixin
 
 CONF = cfg.CONF
 LOG = logging.getLogger('APRSD')
@@ -113,6 +114,7 @@ class NoAPRSFILocationException(Exception):
 
 
 class NearestPlugin(
+    TieredHelpMixin,
     plugin.APRSDRegexCommandPluginBase,
     plugin.APRSFIKEYMixin,
 ):
@@ -130,14 +132,22 @@ class NearestPlugin(
     command_regex = r'^([n]|[n]\s|nearest)'
     command_name = 'nearest'
 
-    def help(self):
-        _help = [
-            'nearest: Return nearest repeaters to your last beacon.',
-            "nearest: Send 'n [count] [band] [+filter]'",
-            'nearest: band: example: 2m, 70cm',
-            'nearest: filter: ex: +echo or +irlp',
+    def help_basic(self) -> list[str]:
+        return [
+            'n [#] [band] [+filter] ex: n 3 70cm +echo',
+            'bands:2m,70cm,6m,1.25m filters:echo,dmr,dstar',
         ]
-        return _help
+
+    def help_full(self) -> list[str]:
+        return [
+            'n [#] [band] [+filter] - find nearest repeaters',
+            'bands: 2m,70cm,6m,1.25m,33cm,23cm,13cm,9cm,5cm,3cm',
+            'filters: echo,irlp,dmr,dstar,ares,races,skywarn',
+            'filters: allstar,wires,fm',
+            'response: CALL FREQ OFFSET TONE DIST DIR',
+            'ex: n 3 70cm +echo (3 70cm echolink repeaters)',
+            'ex: n 5 2m +dmr (5 2m DMR repeaters)',
+        ]
 
     @staticmethod
     def isfloat(value):
@@ -392,14 +402,20 @@ class NearestObjectPlugin(NearestPlugin):
     command_regex = r'^([o]|[o]\s|object)'
     command_name = 'object'
 
-    def help(self):
-        _help = [
-            'object: Return nearest repeaters as APRS object to your last beacon.',
-            "object: Send 'o [count] [band] [+filter]'",
-            'object: band: example: 2m, 70cm',
-            'object: filter: ex: +echo or +irlp',
+    def help_basic(self) -> list[str]:
+        return [
+            'o [#] [band] [+filter] ex: o 2 2m +irlp',
+            'bands:2m,70cm,6m,1.25m filters:echo,dmr,dstar',
         ]
-        return _help
+
+    def help_full(self) -> list[str]:
+        return [
+            'o [#] [band] [+filter] - repeaters as APRS objects',
+            'bands: 2m,70cm,6m,1.25m,33cm,23cm,13cm,9cm,5cm,3cm',
+            'filters: echo,irlp,dmr,dstar,ares,races,skywarn',
+            'filters: allstar,wires,fm',
+            'ex: o 2 70cm (2 nearest 70cm as objects)',
+        ]
 
     def decdeg2dms(self, degrees_decimal):
         is_positive = degrees_decimal >= 0

--- a/aprsd_repeat_plugins/version.py
+++ b/aprsd_repeat_plugins/version.py
@@ -3,15 +3,16 @@ import logging
 from aprsd import plugin
 
 import aprsd_repeat_plugins
+from aprsd_repeat_plugins.help import TieredHelpMixin
 
 LOG = logging.getLogger('APRSD')
 
 
-class VersionPlugin(plugin.APRSDRegexCommandPluginBase):
+class VersionPlugin(TieredHelpMixin, plugin.APRSDRegexCommandPluginBase):
     version = aprsd_repeat_plugins.__version__
-    # Look for any command that starts with w or W
+    # Look for any command that starts with v or V
     command_regex = '^[vV]'
-    # the command is for ?
+    # the command is for version
     command_name = 'version'
 
     enabled = False
@@ -19,6 +20,12 @@ class VersionPlugin(plugin.APRSDRegexCommandPluginBase):
     def setup(self):
         # Do some checks here?
         self.enabled = True
+
+    def help_basic(self) -> list[str]:
+        return ['v - shows REPEAT plugin version']
+
+    def help_full(self) -> list[str]:
+        return ['v or version - shows REPEAT plugin version']
 
     def process(self, packet):
         """This is called when a received packet matches self.command_regex."""

--- a/docs/superpowers/plans/2026-03-19-tiered-help-implementation.md
+++ b/docs/superpowers/plans/2026-03-19-tiered-help-implementation.md
@@ -1,0 +1,914 @@
+# Tiered Help System Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement a tiered help system for APRSD REPEAT plugins with basic (1-2 messages) and full (4-8 messages) help tiers.
+
+**Architecture:** Create a `TieredHelpMixin` base class that `NearestPlugin`, `NearestObjectPlugin`, and `VersionPlugin` inherit from. Create a `RepeatHelpPlugin` that handles `help`, `help <plugin>`, and `help <plugin> full` commands by dispatching to the appropriate `help_basic()` or `help_full()` methods.
+
+**Tech Stack:** Python 3.11+, APRSD plugin framework, unittest
+
+**Spec:** `docs/superpowers/specs/2026-03-19-tiered-help-design.md`
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|------|----------------|
+| `aprsd_repeat_plugins/help.py` (NEW) | `TieredHelpMixin` base class + `RepeatHelpPlugin` |
+| `aprsd_repeat_plugins/nearest.py` (MODIFY) | Add mixin inheritance, implement `help_basic()` and `help_full()` |
+| `aprsd_repeat_plugins/version.py` (MODIFY) | Add mixin inheritance, implement `help_basic()` and `help_full()` |
+| `tests/test_help.py` (NEW) | Tests for mixin and help plugin |
+
+---
+
+## Chunk 1: TieredHelpMixin Base Class
+
+### Task 1: Create TieredHelpMixin with tests
+
+**Files:**
+- Create: `aprsd_repeat_plugins/help.py`
+- Create: `tests/test_help.py`
+
+- [ ] **Step 1: Write failing test for TieredHelpMixin interface**
+
+Create `tests/test_help.py`:
+
+```python
+#!/usr/bin/env python
+"""Tests for tiered help system."""
+
+import unittest
+
+from aprsd_repeat_plugins.help import TieredHelpMixin, MAX_APRS_MSG_LEN
+
+
+class MockPlugin(TieredHelpMixin):
+    """Mock plugin for testing mixin."""
+
+    command_name = 'mock'
+
+    def help_basic(self):
+        return ['mock: basic help']
+
+    def help_full(self):
+        return ['mock: full help line 1', 'mock: full help line 2']
+
+
+class TestTieredHelpMixin(unittest.TestCase):
+    def setUp(self):
+        self.plugin = MockPlugin()
+
+    def test_help_basic_returns_list(self):
+        result = self.plugin.help_basic()
+        self.assertIsInstance(result, list)
+        self.assertEqual(result, ['mock: basic help'])
+
+    def test_help_full_returns_list(self):
+        result = self.plugin.help_full()
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 2)
+
+    def test_help_returns_help_basic_for_backward_compat(self):
+        result = self.plugin.help()
+        self.assertEqual(result, self.plugin.help_basic())
+
+    def test_max_aprs_msg_len_constant(self):
+        self.assertEqual(MAX_APRS_MSG_LEN, 67)
+
+    def test_validate_help_messages_logs_warning_for_long_message(self):
+        """Test that _validate_help_messages logs warning for messages > 67 chars."""
+        long_msg = 'x' * 70  # 70 chars, exceeds 67 limit
+        with self.assertLogs('APRSD', level='WARNING') as log:
+            self.plugin._validate_help_messages([long_msg])
+        self.assertTrue(any('exceeds 67 chars' in msg for msg in log.output))
+
+    def test_validate_help_messages_no_warning_for_short_message(self):
+        """Test that _validate_help_messages does not warn for messages <= 67 chars."""
+        short_msg = 'x' * 67  # Exactly 67 chars, at limit
+        # Should not raise any warnings
+        result = self.plugin._validate_help_messages([short_msg])
+        self.assertEqual(result, [short_msg])
+
+
+if __name__ == '__main__':
+    unittest.main()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_help.py -v`
+Expected: FAIL with "ModuleNotFoundError: No module named 'aprsd_repeat_plugins.help'"
+
+- [ ] **Step 3: Write TieredHelpMixin implementation**
+
+Create `aprsd_repeat_plugins/help.py`:
+
+```python
+"""Tiered help system for APRSD REPEAT plugins."""
+
+import abc
+import logging
+
+LOG = logging.getLogger('APRSD')
+
+MAX_APRS_MSG_LEN = 67
+
+
+class TieredHelpMixin(abc.ABC):
+    """Mixin providing tiered help for APRS plugins.
+
+    Plugins inherit from this mixin and implement help_basic() and help_full().
+    The help() method returns help_basic() for backward compatibility with
+    APRSD's built-in HelpPlugin.
+    """
+
+    @abc.abstractmethod
+    def help_basic(self) -> list[str]:
+        """Return 1-2 short messages with syntax and options preview.
+
+        Returns:
+            List of help message strings, each <=67 chars for APRS.
+        """
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def help_full(self) -> list[str]:
+        """Return complete reference with all bands, filters, and examples.
+
+        Returns:
+            List of help message strings, each <=67 chars for APRS.
+        """
+        raise NotImplementedError
+
+    def help(self) -> list[str]:
+        """Return basic help for backward compatibility.
+
+        This is called by APRSD's built-in HelpPlugin.
+
+        Returns:
+            Result of help_basic().
+        """
+        return self.help_basic()
+
+    def _validate_help_messages(self, messages: list[str]) -> list[str]:
+        """Log warning if any message exceeds APRS limit.
+
+        Args:
+            messages: List of help message strings.
+
+        Returns:
+            The same list of messages (for chaining).
+        """
+        for msg in messages:
+            if len(msg) > MAX_APRS_MSG_LEN:
+                LOG.warning(
+                    f'Help message exceeds {MAX_APRS_MSG_LEN} chars '
+                    f'({len(msg)}): {msg}',
+                )
+        return messages
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_help.py -v`
+Expected: PASS (6 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add aprsd_repeat_plugins/help.py tests/test_help.py
+git commit -m "feat: add TieredHelpMixin base class for tiered help system"
+```
+
+---
+
+## Chunk 2: RepeatHelpPlugin
+
+### Task 2: Create RepeatHelpPlugin with tests
+
+**Files:**
+- Modify: `aprsd_repeat_plugins/help.py`
+- Modify: `tests/test_help.py`
+
+- [ ] **Step 1: Write failing tests for RepeatHelpPlugin**
+
+Add to `tests/test_help.py`:
+
+```python
+from unittest.mock import MagicMock, patch
+
+from aprsd_repeat_plugins.help import RepeatHelpPlugin
+
+
+class TestRepeatHelpPlugin(unittest.TestCase):
+    def setUp(self):
+        self.plugin = RepeatHelpPlugin()
+
+    def test_command_regex_matches_help(self):
+        import re
+        pattern = re.compile(self.plugin.command_regex)
+        self.assertIsNotNone(pattern.match('help'))
+        self.assertIsNotNone(pattern.match('Help'))
+        self.assertIsNotNone(pattern.match('h'))
+        self.assertIsNotNone(pattern.match('H'))
+
+    def test_command_name(self):
+        self.assertEqual(self.plugin.command_name, 'help')
+
+    def test_help_basic_returns_list(self):
+        result = self.plugin.help_basic()
+        self.assertIsInstance(result, list)
+
+    def test_help_full_returns_list(self):
+        result = self.plugin.help_full()
+        self.assertIsInstance(result, list)
+
+
+class TestRepeatHelpPluginParsing(unittest.TestCase):
+    def setUp(self):
+        self.plugin = RepeatHelpPlugin()
+
+    def test_parse_help_alone(self):
+        cmd, plugin_name, is_full = self.plugin._parse_help_message('help')
+        self.assertEqual(cmd, 'help')
+        self.assertIsNone(plugin_name)
+        self.assertFalse(is_full)
+
+    def test_parse_help_plugin(self):
+        cmd, plugin_name, is_full = self.plugin._parse_help_message('help nearest')
+        self.assertEqual(cmd, 'help')
+        self.assertEqual(plugin_name, 'nearest')
+        self.assertFalse(is_full)
+
+    def test_parse_help_plugin_full(self):
+        cmd, plugin_name, is_full = self.plugin._parse_help_message('help nearest full')
+        self.assertEqual(cmd, 'help')
+        self.assertEqual(plugin_name, 'nearest')
+        self.assertTrue(is_full)
+
+    def test_parse_h_shorthand(self):
+        cmd, plugin_name, is_full = self.plugin._parse_help_message('h')
+        self.assertEqual(cmd, 'h')
+        self.assertIsNone(plugin_name)
+        self.assertFalse(is_full)
+
+    def test_parse_h_plugin(self):
+        cmd, plugin_name, is_full = self.plugin._parse_help_message('h nearest')
+        self.assertEqual(cmd, 'h')
+        self.assertEqual(plugin_name, 'nearest')
+        self.assertFalse(is_full)
+
+
+class TestRepeatHelpPluginProcess(unittest.TestCase):
+    """Tests for RepeatHelpPlugin.process() dispatch logic."""
+
+    def setUp(self):
+        self.plugin = RepeatHelpPlugin()
+
+    def test_process_help_alone_returns_plugin_list(self):
+        """Test that 'help' alone lists available plugins."""
+        packet = MagicMock()
+        packet.message_text = 'help'
+
+        # Mock _get_repeat_plugins to return known plugins
+        mock_nearest = MagicMock()
+        mock_nearest.command_name = 'nearest'
+        mock_nearest.help_basic.return_value = ['nearest help']
+
+        with patch.object(self.plugin, '_get_repeat_plugins', return_value={'nearest': mock_nearest}):
+            result = self.plugin.process(packet)
+
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 2)
+        self.assertIn('plugins:', result[1])
+
+    def test_process_help_plugin_returns_basic_help(self):
+        """Test that 'help nearest' returns basic help."""
+        packet = MagicMock()
+        packet.message_text = 'help nearest'
+
+        mock_nearest = MagicMock()
+        mock_nearest.command_name = 'nearest'
+        mock_nearest.help_basic.return_value = ['nearest basic help']
+
+        with patch.object(self.plugin, '_get_repeat_plugins', return_value={'nearest': mock_nearest}):
+            result = self.plugin.process(packet)
+
+        mock_nearest.help_basic.assert_called_once()
+        self.assertEqual(result, ['nearest basic help'])
+
+    def test_process_help_plugin_full_returns_full_help(self):
+        """Test that 'help nearest full' returns full help."""
+        packet = MagicMock()
+        packet.message_text = 'help nearest full'
+
+        mock_nearest = MagicMock()
+        mock_nearest.command_name = 'nearest'
+        mock_nearest.help_full.return_value = ['nearest full help line 1', 'line 2']
+
+        with patch.object(self.plugin, '_get_repeat_plugins', return_value={'nearest': mock_nearest}):
+            result = self.plugin.process(packet)
+
+        mock_nearest.help_full.assert_called_once()
+        self.assertEqual(result, ['nearest full help line 1', 'line 2'])
+
+    def test_process_unknown_plugin_returns_error(self):
+        """Test that 'help unknown' returns error message."""
+        packet = MagicMock()
+        packet.message_text = 'help unknown'
+
+        mock_nearest = MagicMock()
+        mock_nearest.command_name = 'nearest'
+
+        with patch.object(self.plugin, '_get_repeat_plugins', return_value={'nearest': mock_nearest}):
+            result = self.plugin.process(packet)
+
+        self.assertIn("Unknown plugin 'unknown'", result)
+        self.assertIn('nearest', result)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_help.py::TestRepeatHelpPlugin -v`
+Expected: FAIL with "ImportError: cannot import name 'RepeatHelpPlugin'"
+
+- [ ] **Step 3: Write RepeatHelpPlugin implementation**
+
+Add to `aprsd_repeat_plugins/help.py`:
+
+```python
+import re
+
+from aprsd import plugin
+from oslo_config import cfg
+
+import aprsd_repeat_plugins
+
+CONF = cfg.CONF
+
+# Plugin name to command_name mapping for REPEAT plugins
+REPEAT_PLUGINS = {
+    'nearest': 'nearest',
+    'object': 'object',
+    'version': 'version',
+    'help': 'help',
+}
+
+
+class RepeatHelpPlugin(TieredHelpMixin, plugin.APRSDRegexCommandPluginBase):
+    """Help plugin for APRSD REPEAT service.
+
+    Replaces APRSD's built-in HelpPlugin with tiered help support.
+    Handles:
+    - help (list available plugins)
+    - help <plugin> (basic help for plugin)
+    - help <plugin> full (detailed help for plugin)
+    """
+
+    version = aprsd_repeat_plugins.__version__
+    command_regex = r'^[hH](elp)?'
+    command_name = 'help'
+
+    def help_basic(self) -> list[str]:
+        return ["help <plugin> or help <plugin> full"]
+
+    def help_full(self) -> list[str]:
+        return [
+            "help - list available plugins",
+            "help <plugin> - basic help for plugin",
+            "help <plugin> full - detailed help",
+            "plugins: nearest, object, version",
+        ]
+
+    def setup(self):
+        """Plugin setup."""
+        self.enabled = True
+
+    def _parse_help_message(self, message: str) -> tuple[str, str | None, bool]:
+        """Parse help message to extract command, plugin name, and full flag.
+
+        Args:
+            message: The message text (e.g., "help nearest full")
+
+        Returns:
+            Tuple of (command, plugin_name or None, is_full bool)
+        """
+        parts = message.strip().lower().split()
+        cmd = parts[0] if parts else ''
+        plugin_name = None
+        is_full = False
+
+        if len(parts) >= 2:
+            plugin_name = parts[1]
+        if len(parts) >= 3 and parts[2] == 'full':
+            is_full = True
+
+        return cmd, plugin_name, is_full
+
+    def _get_repeat_plugins(self) -> dict:
+        """Get all enabled REPEAT plugins that have TieredHelpMixin.
+
+        Returns:
+            Dict mapping command_name to plugin instance.
+        """
+        from aprsd.plugin import PluginManager
+
+        pm = PluginManager()
+        plugins = {}
+
+        for p in pm.get_plugins():
+            if (
+                p.enabled
+                and hasattr(p, 'command_name')
+                and isinstance(p, TieredHelpMixin)
+                and p.command_name != 'help'  # Exclude self
+            ):
+                plugins[p.command_name.lower()] = p
+
+        return plugins
+
+    def process(self, packet):
+        """Process help command.
+
+        Args:
+            packet: APRS message packet.
+
+        Returns:
+            Help response string or list of strings.
+        """
+        LOG.info('RepeatHelpPlugin')
+
+        message = packet.message_text
+        _, plugin_name, is_full = self._parse_help_message(message)
+
+        # Get available REPEAT plugins
+        plugins = self._get_repeat_plugins()
+
+        if plugin_name is None:
+            # User sent just "help" - list available plugins
+            plugin_names = sorted(plugins.keys())
+            if plugin_names:
+                return [
+                    "Send 'help <plugin>' or 'help <plugin> full'",
+                    f"plugins: {' '.join(plugin_names)}",
+                ]
+            return "No plugins available"
+
+        # User wants help for a specific plugin
+        if plugin_name in plugins:
+            p = plugins[plugin_name]
+            if is_full:
+                return p.help_full()
+            return p.help_basic()
+
+        # Unknown plugin
+        available = ', '.join(sorted(plugins.keys()))
+        return f"Unknown plugin '{plugin_name}'. Available: {available}"
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_help.py -v`
+Expected: PASS (all tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add aprsd_repeat_plugins/help.py tests/test_help.py
+git commit -m "feat: add RepeatHelpPlugin for tiered help dispatch"
+```
+
+---
+
+## Chunk 3: Update NearestPlugin with Tiered Help
+
+### Task 3: Add TieredHelpMixin to NearestPlugin
+
+**Files:**
+- Modify: `aprsd_repeat_plugins/nearest.py`
+- Modify: `tests/test_help.py`
+
+- [ ] **Step 1: Write failing tests for NearestPlugin help methods**
+
+Add to `tests/test_help.py`:
+
+```python
+from aprsd_repeat_plugins.nearest import NearestPlugin, NearestObjectPlugin
+from aprsd_repeat_plugins.help import MAX_APRS_MSG_LEN
+
+
+class TestNearestPluginHelp(unittest.TestCase):
+    def setUp(self):
+        self.plugin = NearestPlugin()
+
+    def test_is_tiered_help_mixin(self):
+        self.assertIsInstance(self.plugin, TieredHelpMixin)
+
+    def test_help_basic_returns_list(self):
+        result = self.plugin.help_basic()
+        self.assertIsInstance(result, list)
+        self.assertGreaterEqual(len(result), 1)
+        self.assertLessEqual(len(result), 2)
+
+    def test_help_full_returns_list(self):
+        result = self.plugin.help_full()
+        self.assertIsInstance(result, list)
+        self.assertGreaterEqual(len(result), 4)
+
+    def test_help_basic_messages_under_limit(self):
+        for msg in self.plugin.help_basic():
+            self.assertLessEqual(
+                len(msg), MAX_APRS_MSG_LEN,
+                f"Message too long ({len(msg)} chars): {msg}"
+            )
+
+    def test_help_full_messages_under_limit(self):
+        for msg in self.plugin.help_full():
+            self.assertLessEqual(
+                len(msg), MAX_APRS_MSG_LEN,
+                f"Message too long ({len(msg)} chars): {msg}"
+            )
+
+    def test_help_returns_help_basic(self):
+        self.assertEqual(self.plugin.help(), self.plugin.help_basic())
+
+
+class TestNearestObjectPluginHelp(unittest.TestCase):
+    def setUp(self):
+        self.plugin = NearestObjectPlugin()
+
+    def test_is_tiered_help_mixin(self):
+        self.assertIsInstance(self.plugin, TieredHelpMixin)
+
+    def test_help_basic_returns_list(self):
+        result = self.plugin.help_basic()
+        self.assertIsInstance(result, list)
+        self.assertGreaterEqual(len(result), 1)
+        self.assertLessEqual(len(result), 2)
+
+    def test_help_full_returns_list(self):
+        result = self.plugin.help_full()
+        self.assertIsInstance(result, list)
+        self.assertGreaterEqual(len(result), 4)
+
+    def test_help_basic_messages_under_limit(self):
+        for msg in self.plugin.help_basic():
+            self.assertLessEqual(
+                len(msg), MAX_APRS_MSG_LEN,
+                f"Message too long ({len(msg)} chars): {msg}"
+            )
+
+    def test_help_full_messages_under_limit(self):
+        for msg in self.plugin.help_full():
+            self.assertLessEqual(
+                len(msg), MAX_APRS_MSG_LEN,
+                f"Message too long ({len(msg)} chars): {msg}"
+            )
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_help.py::TestNearestPluginHelp -v`
+Expected: FAIL with "AssertionError: NearestPlugin is not TieredHelpMixin"
+
+- [ ] **Step 3: Update NearestPlugin to inherit from TieredHelpMixin**
+
+Modify `aprsd_repeat_plugins/nearest.py`:
+
+1. Add import at top:
+```python
+from aprsd_repeat_plugins.help import TieredHelpMixin
+```
+
+2. Change class definition:
+```python
+class NearestPlugin(
+    TieredHelpMixin,
+    plugin.APRSDRegexCommandPluginBase,
+    plugin.APRSFIKEYMixin,
+):
+```
+
+3. DELETE the existing `help()` method (around line 133) and replace with:
+```python
+    def help_basic(self) -> list[str]:
+        return [
+            "n [#] [band] [+filter] ex: n 3 70cm +echo",
+            "bands:2m,70cm,6m,1.25m filters:echo,dmr,dstar",
+        ]
+
+    def help_full(self) -> list[str]:
+        return [
+            "n [#] [band] [+filter] - find nearest repeaters",
+            "bands: 2m,70cm,6m,1.25m,33cm,23cm,13cm,9cm,5cm,3cm",
+            "filters: echo,irlp,dmr,dstar,ares,races,skywarn",
+            "filters: allstar,wires,fm",
+            "response: CALL FREQ OFFSET TONE DIST DIR",
+            "ex: n 3 70cm +echo (3 70cm echolink repeaters)",
+            "ex: n 5 2m +dmr (5 2m DMR repeaters)",
+        ]
+```
+
+- [ ] **Step 4: Update NearestObjectPlugin help methods**
+
+In `NearestObjectPlugin` class (around line 395), DELETE the existing `help()` method:
+```python
+    # DELETE THIS METHOD:
+    def help(self):
+        _help = [
+            'object: Return nearest repeaters as APRS object to your last beacon.',
+            "object: Send 'o [count] [band] [+filter]'",
+            'object: band: example: 2m, 70cm',
+            'object: filter: ex: +echo or +irlp',
+        ]
+        return _help
+```
+
+Then ADD the new tiered help methods in its place:
+```python
+    def help_basic(self) -> list[str]:
+        return [
+            "o [#] [band] [+filter] ex: o 2 2m +irlp",
+            "bands:2m,70cm,6m,1.25m filters:echo,dmr,dstar",
+        ]
+
+    def help_full(self) -> list[str]:
+        return [
+            "o [#] [band] [+filter] - repeaters as APRS objects",
+            "bands: 2m,70cm,6m,1.25m,33cm,23cm,13cm,9cm,5cm,3cm",
+            "filters: echo,irlp,dmr,dstar,ares,races,skywarn",
+            "filters: allstar,wires,fm",
+            "ex: o 2 70cm (2 nearest 70cm as objects)",
+        ]
+```
+
+Note: `NearestObjectPlugin` inherits from `NearestPlugin`, which now inherits from `TieredHelpMixin`. The mixin is acquired through inheritance (Python MRO handles this correctly). By removing the old `help()` method and adding `help_basic()` and `help_full()`, the mixin's `help()` method will be inherited and used (which calls `help_basic()`).
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_help.py -v`
+Expected: PASS (all tests)
+
+- [ ] **Step 6: Run existing tests to ensure no regression**
+
+Run: `python -m pytest tests/ -v`
+Expected: PASS (all existing tests still pass)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add aprsd_repeat_plugins/nearest.py tests/test_help.py
+git commit -m "feat: add tiered help to NearestPlugin and NearestObjectPlugin"
+```
+
+---
+
+## Chunk 4: Update VersionPlugin with Tiered Help
+
+### Task 4: Add TieredHelpMixin to VersionPlugin
+
+**Files:**
+- Modify: `aprsd_repeat_plugins/version.py`
+- Modify: `tests/test_help.py`
+
+- [ ] **Step 1: Write failing tests for VersionPlugin help methods**
+
+Add to `tests/test_help.py`:
+
+```python
+from aprsd_repeat_plugins.version import VersionPlugin
+
+
+class TestVersionPluginHelp(unittest.TestCase):
+    def setUp(self):
+        self.plugin = VersionPlugin()
+
+    def test_is_tiered_help_mixin(self):
+        self.assertIsInstance(self.plugin, TieredHelpMixin)
+
+    def test_help_basic_returns_list(self):
+        result = self.plugin.help_basic()
+        self.assertIsInstance(result, list)
+        self.assertGreaterEqual(len(result), 1)
+
+    def test_help_full_returns_list(self):
+        result = self.plugin.help_full()
+        self.assertIsInstance(result, list)
+        self.assertGreaterEqual(len(result), 1)
+
+    def test_help_basic_messages_under_limit(self):
+        for msg in self.plugin.help_basic():
+            self.assertLessEqual(
+                len(msg), MAX_APRS_MSG_LEN,
+                f"Message too long ({len(msg)} chars): {msg}"
+            )
+
+    def test_help_full_messages_under_limit(self):
+        for msg in self.plugin.help_full():
+            self.assertLessEqual(
+                len(msg), MAX_APRS_MSG_LEN,
+                f"Message too long ({len(msg)} chars): {msg}"
+            )
+
+    def test_help_returns_help_basic(self):
+        self.assertEqual(self.plugin.help(), self.plugin.help_basic())
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_help.py::TestVersionPluginHelp -v`
+Expected: FAIL with "AssertionError: VersionPlugin is not TieredHelpMixin"
+
+- [ ] **Step 3: Update VersionPlugin to inherit from TieredHelpMixin**
+
+Modify `aprsd_repeat_plugins/version.py`:
+
+```python
+import logging
+
+from aprsd import plugin
+
+import aprsd_repeat_plugins
+from aprsd_repeat_plugins.help import TieredHelpMixin
+
+LOG = logging.getLogger('APRSD')
+
+
+class VersionPlugin(TieredHelpMixin, plugin.APRSDRegexCommandPluginBase):
+    version = aprsd_repeat_plugins.__version__
+    # Look for any command that starts with v or V
+    command_regex = '^[vV]'
+    # the command is for version
+    command_name = 'version'
+
+    enabled = False
+
+    def setup(self):
+        # Do some checks here?
+        self.enabled = True
+
+    def help_basic(self) -> list[str]:
+        return ["v - shows REPEAT plugin version"]
+
+    def help_full(self) -> list[str]:
+        return ["v or version - shows REPEAT plugin version"]
+
+    def process(self, packet):
+        """This is called when a received packet matches self.command_regex."""
+
+        LOG.info('VersionPlugin')
+
+        return f'APRS REPEAT Version: {aprsd_repeat_plugins.__version__}'
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_help.py::TestVersionPluginHelp -v`
+Expected: PASS (all tests)
+
+- [ ] **Step 5: Run all tests to ensure no regression**
+
+Run: `python -m pytest tests/ -v`
+Expected: PASS (all tests)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add aprsd_repeat_plugins/version.py tests/test_help.py
+git commit -m "feat: add tiered help to VersionPlugin"
+```
+
+---
+
+## Chunk 5: Integration Test and Documentation
+
+### Task 5: Add integration tests and update README
+
+**Files:**
+- Modify: `tests/test_help.py`
+- Modify: `README.md`
+
+- [ ] **Step 1: Write integration test for help flow**
+
+Add to `tests/test_help.py`:
+
+```python
+class TestHelpIntegration(unittest.TestCase):
+    """Integration tests for the full help flow."""
+
+    def test_all_basic_help_messages_under_limit(self):
+        """Verify all plugins have compliant basic help messages."""
+        plugins = [
+            NearestPlugin(),
+            NearestObjectPlugin(),
+            VersionPlugin(),
+            RepeatHelpPlugin(),
+        ]
+        for p in plugins:
+            for msg in p.help_basic():
+                self.assertLessEqual(
+                    len(msg), MAX_APRS_MSG_LEN,
+                    f"{p.command_name} basic help too long ({len(msg)}): {msg}"
+                )
+
+    def test_all_full_help_messages_under_limit(self):
+        """Verify all plugins have compliant full help messages."""
+        plugins = [
+            NearestPlugin(),
+            NearestObjectPlugin(),
+            VersionPlugin(),
+            RepeatHelpPlugin(),
+        ]
+        for p in plugins:
+            for msg in p.help_full():
+                self.assertLessEqual(
+                    len(msg), MAX_APRS_MSG_LEN,
+                    f"{p.command_name} full help too long ({len(msg)}): {msg}"
+                )
+```
+
+- [ ] **Step 2: Run integration tests**
+
+Run: `python -m pytest tests/test_help.py::TestHelpIntegration -v`
+Expected: PASS
+
+- [ ] **Step 3: Update README.md with help usage**
+
+Add the following section to README.md. Insert it after the "### VersionPlugin" section and the "#### Example Interaction" subsection, before the "## Response Format" section:
+
+```markdown
+### Help System
+
+The REPEAT plugins include a tiered help system to provide concise or detailed
+help over APRS without flooding the network.
+
+#### Basic Help
+
+Send `help <plugin>` for a quick syntax reference (1-2 messages):
+
+```
+help nearest
+help object
+help version
+```
+
+#### Detailed Help
+
+Send `help <plugin> full` for complete documentation (4-8 messages):
+
+```
+help nearest full
+help object full
+```
+
+#### RepeatHelpPlugin Configuration
+
+To use the REPEAT help system, enable `RepeatHelpPlugin` and disable APRSD's
+built-in HelpPlugin:
+
+```yaml
+aprsd:
+  enabled_plugins:
+    - aprsd_repeat_plugins.help.RepeatHelpPlugin
+    - aprsd_repeat_plugins.nearest.NearestPlugin
+    - aprsd_repeat_plugins.nearest.NearestObjectPlugin
+    - aprsd_repeat_plugins.version.VersionPlugin
+```
+```
+
+- [ ] **Step 4: Run full test suite**
+
+Run: `python -m pytest tests/ -v`
+Expected: PASS (all tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/test_help.py README.md
+git commit -m "docs: add help system documentation and integration tests"
+```
+
+---
+
+## Final Verification
+
+- [ ] **Run full test suite one more time**
+
+Run: `python -m pytest tests/ -v`
+Expected: All tests PASS
+
+- [ ] **Run linter**
+
+Run: `tox -e lint` or `ruff check .`
+Expected: No errors
+
+- [ ] **Test manually (optional)**
+
+If APRSD is configured locally, test with actual APRS messages:
+- Send `help`
+- Send `help nearest`
+- Send `help nearest full`
+- Send `help object`
+- Send `help object full`

--- a/docs/superpowers/specs/2026-03-19-tiered-help-design.md
+++ b/docs/superpowers/specs/2026-03-19-tiered-help-design.md
@@ -1,0 +1,138 @@
+# Design: Tiered Help System for APRSD REPEAT Plugins
+
+**Date:** 2026-03-19
+**Status:** Approved
+
+## Overview
+
+Implement a tiered help system for APRSD REPEAT plugins that balances informativeness with APRS message length constraints (~67 chars max). Users can request basic help (`help nearest`) or detailed help (`help nearest full`).
+
+## Problem
+
+Current help responses are either:
+- Too verbose (4 messages per plugin = radio traffic congestion)
+- Not informative enough (users don't know all available bands/filters)
+
+## Solution
+
+A two-tier help system:
+- **Basic help**: 1-2 messages with syntax + preview of options
+- **Full help**: 4-8 messages with complete bands, filters, response format, and examples
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    RepeatHelpPlugin                          │
+│  - Replaces APRSD's built-in HelpPlugin                     │
+│  - Parses: "help", "help <plugin>", "help <plugin> full"    │
+│  - Dispatches to help_basic() or help_full()                │
+└─────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────┐
+│                    TieredHelpMixin                           │
+│  - help_basic() → 1-2 short messages                        │
+│  - help_full() → complete reference                         │
+│  - help() → backward compat, returns help_basic()           │
+└─────────────────────────────────────────────────────────────┘
+                              │
+            ┌─────────────────┼─────────────────┐
+            ▼                 ▼                 ▼
+     NearestPlugin    NearestObjectPlugin   VersionPlugin
+```
+
+## File Changes
+
+### New file: `aprsd_repeat_plugins/help.py`
+
+- `TieredHelpMixin` class with abstract `help_basic()` and `help_full()` methods
+- `RepeatHelpPlugin` that handles help command dispatch
+- `MAX_APRS_MSG_LEN = 67` constant for validation
+
+### Modify: `aprsd_repeat_plugins/nearest.py`
+
+- `NearestPlugin` inherits from `TieredHelpMixin`
+- Implements `help_basic()` and `help_full()`
+- `NearestObjectPlugin` inherits from `NearestPlugin` (already does), gets mixin via inheritance
+
+### Modify: `aprsd_repeat_plugins/version.py`
+
+- `VersionPlugin` inherits from `TieredHelpMixin`
+- Implements `help_basic()` and `help_full()`
+
+## Message Content
+
+### NearestPlugin basic (2 messages)
+
+```
+n [#] [band] [+filter] ex: n 3 70cm +echo
+bands:2m,70cm,6m,1.25m filters:echo,dmr,dstar
+```
+
+### NearestPlugin full (7 messages)
+
+```
+n [#] [band] [+filter] - find nearest repeaters
+bands: 2m,70cm,6m,1.25m,33cm,23cm,13cm,9cm,5cm,3cm
+filters: echo,irlp,dmr,dstar,ares,races,skywarn
+filters: allstar,wires,fm
+response: CALL FREQ OFFSET TONE DIST DIR
+ex: n 3 70cm +echo (3 70cm echolink repeaters)
+ex: n 5 2m +dmr (5 2m DMR repeaters)
+```
+
+### NearestObjectPlugin basic (2 messages)
+
+```
+o [#] [band] [+filter] ex: o 2 2m +irlp
+bands:2m,70cm,6m,1.25m filters:echo,dmr,dstar
+```
+
+### NearestObjectPlugin full (5 messages)
+
+```
+o [#] [band] [+filter] - repeaters as APRS objects
+bands: 2m,70cm,6m,1.25m,33cm,23cm,13cm,9cm,5cm,3cm
+filters: echo,irlp,dmr,dstar,ares,races,skywarn
+filters: allstar,wires,fm
+ex: o 2 70cm (2 nearest 70cm as objects)
+```
+
+### VersionPlugin basic (1 message)
+
+```
+v - shows REPEAT plugin version
+```
+
+### VersionPlugin full (1 message)
+
+```
+v or version - shows REPEAT plugin version
+```
+
+## Configuration
+
+Users disable APRSD's built-in HelpPlugin and enable RepeatHelpPlugin:
+
+```yaml
+aprsd:
+  enabled_plugins:
+    - aprsd_repeat_plugins.help.RepeatHelpPlugin
+    - aprsd_repeat_plugins.nearest.NearestPlugin
+    - aprsd_repeat_plugins.nearest.NearestObjectPlugin
+    - aprsd_repeat_plugins.version.VersionPlugin
+```
+
+## Error Handling
+
+1. `help` alone → List available plugins: "plugins: nearest object version"
+2. `help <unknown>` → "Unknown plugin. Available: nearest, object, version"
+3. Message length validation → Log warning if any help message exceeds 67 chars
+
+## Testing
+
+- Unit tests for `TieredHelpMixin` interface
+- Unit tests for `RepeatHelpPlugin` parsing (`help`, `help nearest`, `help nearest full`)
+- Verify all help messages are ≤67 characters
+- Integration test with mock packet

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -2,8 +2,13 @@
 """Tests for tiered help system."""
 
 import unittest
+from unittest.mock import MagicMock, patch
 
-from aprsd_repeat_plugins.help import MAX_APRS_MSG_LEN, TieredHelpMixin
+from aprsd_repeat_plugins.help import (
+    MAX_APRS_MSG_LEN,
+    RepeatHelpPlugin,
+    TieredHelpMixin,
+)
 
 
 class MockPlugin(TieredHelpMixin):
@@ -52,6 +57,152 @@ class TestTieredHelpMixin(unittest.TestCase):
         # Should not raise any warnings
         result = self.plugin._validate_help_messages([short_msg])
         self.assertEqual(result, [short_msg])
+
+
+class TestRepeatHelpPlugin(unittest.TestCase):
+    def setUp(self):
+        self.plugin = RepeatHelpPlugin()
+
+    def test_command_regex_matches_help(self):
+        import re
+
+        pattern = re.compile(self.plugin.command_regex)
+        self.assertIsNotNone(pattern.match('help'))
+        self.assertIsNotNone(pattern.match('Help'))
+        self.assertIsNotNone(pattern.match('h'))
+        self.assertIsNotNone(pattern.match('H'))
+
+    def test_command_name(self):
+        self.assertEqual(self.plugin.command_name, 'help')
+
+    def test_help_basic_returns_list(self):
+        result = self.plugin.help_basic()
+        self.assertIsInstance(result, list)
+
+    def test_help_full_returns_list(self):
+        result = self.plugin.help_full()
+        self.assertIsInstance(result, list)
+
+
+class TestRepeatHelpPluginParsing(unittest.TestCase):
+    def setUp(self):
+        self.plugin = RepeatHelpPlugin()
+
+    def test_parse_help_alone(self):
+        cmd, plugin_name, is_full = self.plugin._parse_help_message('help')
+        self.assertEqual(cmd, 'help')
+        self.assertIsNone(plugin_name)
+        self.assertFalse(is_full)
+
+    def test_parse_help_plugin(self):
+        cmd, plugin_name, is_full = self.plugin._parse_help_message('help nearest')
+        self.assertEqual(cmd, 'help')
+        self.assertEqual(plugin_name, 'nearest')
+        self.assertFalse(is_full)
+
+    def test_parse_help_plugin_full(self):
+        cmd, plugin_name, is_full = self.plugin._parse_help_message('help nearest full')
+        self.assertEqual(cmd, 'help')
+        self.assertEqual(plugin_name, 'nearest')
+        self.assertTrue(is_full)
+
+    def test_parse_h_shorthand(self):
+        cmd, plugin_name, is_full = self.plugin._parse_help_message('h')
+        self.assertEqual(cmd, 'h')
+        self.assertIsNone(plugin_name)
+        self.assertFalse(is_full)
+
+    def test_parse_h_plugin(self):
+        cmd, plugin_name, is_full = self.plugin._parse_help_message('h nearest')
+        self.assertEqual(cmd, 'h')
+        self.assertEqual(plugin_name, 'nearest')
+        self.assertFalse(is_full)
+
+
+class TestRepeatHelpPluginProcess(unittest.TestCase):
+    """Tests for RepeatHelpPlugin.process() dispatch logic."""
+
+    def setUp(self):
+        self.plugin = RepeatHelpPlugin()
+
+    def test_process_help_alone_returns_plugin_list(self):
+        """Test that 'help' alone lists available plugins."""
+        packet = MagicMock()
+        packet.message_text = 'help'
+
+        # Mock _get_repeat_plugins to return known plugins
+        mock_nearest = MagicMock()
+        mock_nearest.command_name = 'nearest'
+        mock_nearest.help_basic.return_value = ['nearest help']
+
+        with patch.object(
+            self.plugin, '_get_repeat_plugins', return_value={'nearest': mock_nearest}
+        ):
+            result = self.plugin.process(packet)
+
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 2)
+        self.assertIn('plugins:', result[1])
+
+    def test_process_help_plugin_returns_basic_help(self):
+        """Test that 'help nearest' returns basic help."""
+        packet = MagicMock()
+        packet.message_text = 'help nearest'
+
+        mock_nearest = MagicMock()
+        mock_nearest.command_name = 'nearest'
+        mock_nearest.help_basic.return_value = ['nearest basic help']
+
+        with patch.object(
+            self.plugin, '_get_repeat_plugins', return_value={'nearest': mock_nearest}
+        ):
+            result = self.plugin.process(packet)
+
+        mock_nearest.help_basic.assert_called_once()
+        self.assertEqual(result, ['nearest basic help'])
+
+    def test_process_help_plugin_full_returns_full_help(self):
+        """Test that 'help nearest full' returns full help."""
+        packet = MagicMock()
+        packet.message_text = 'help nearest full'
+
+        mock_nearest = MagicMock()
+        mock_nearest.command_name = 'nearest'
+        mock_nearest.help_full.return_value = ['nearest full help line 1', 'line 2']
+
+        with patch.object(
+            self.plugin, '_get_repeat_plugins', return_value={'nearest': mock_nearest}
+        ):
+            result = self.plugin.process(packet)
+
+        mock_nearest.help_full.assert_called_once()
+        self.assertEqual(result, ['nearest full help line 1', 'line 2'])
+
+    def test_process_unknown_plugin_returns_error(self):
+        """Test that 'help unknown' returns error message."""
+        packet = MagicMock()
+        packet.message_text = 'help unknown'
+
+        mock_nearest = MagicMock()
+        mock_nearest.command_name = 'nearest'
+
+        with patch.object(
+            self.plugin, '_get_repeat_plugins', return_value={'nearest': mock_nearest}
+        ):
+            result = self.plugin.process(packet)
+
+        self.assertIn("Unknown plugin 'unknown'", result)
+        self.assertIn('nearest', result)
+
+    def test_process_help_no_plugins_returns_message(self):
+        """Test that 'help' with no plugins returns appropriate message."""
+        packet = MagicMock()
+        packet.message_text = 'help'
+
+        with patch.object(self.plugin, '_get_repeat_plugins', return_value={}):
+            result = self.plugin.process(packet)
+
+        self.assertEqual(result, 'No plugins available')
 
 
 if __name__ == '__main__':

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -205,5 +205,84 @@ class TestRepeatHelpPluginProcess(unittest.TestCase):
         self.assertEqual(result, 'No plugins available')
 
 
+from aprsd_repeat_plugins.nearest import NearestObjectPlugin, NearestPlugin
+
+
+class TestNearestPluginHelp(unittest.TestCase):
+    def setUp(self):
+        self.plugin = NearestPlugin()
+
+    def test_is_tiered_help_mixin(self):
+        self.assertIsInstance(self.plugin, TieredHelpMixin)
+
+    def test_help_basic_returns_list(self):
+        result = self.plugin.help_basic()
+        self.assertIsInstance(result, list)
+        self.assertGreaterEqual(len(result), 1)
+        self.assertLessEqual(len(result), 2)
+
+    def test_help_full_returns_list(self):
+        result = self.plugin.help_full()
+        self.assertIsInstance(result, list)
+        self.assertGreaterEqual(len(result), 4)
+
+    def test_help_basic_messages_under_limit(self):
+        for msg in self.plugin.help_basic():
+            self.assertLessEqual(
+                len(msg),
+                MAX_APRS_MSG_LEN,
+                f'Message too long ({len(msg)} chars): {msg}',
+            )
+
+    def test_help_full_messages_under_limit(self):
+        for msg in self.plugin.help_full():
+            self.assertLessEqual(
+                len(msg),
+                MAX_APRS_MSG_LEN,
+                f'Message too long ({len(msg)} chars): {msg}',
+            )
+
+    def test_help_returns_help_basic(self):
+        self.assertEqual(self.plugin.help(), self.plugin.help_basic())
+
+
+class TestNearestObjectPluginHelp(unittest.TestCase):
+    def setUp(self):
+        self.plugin = NearestObjectPlugin()
+
+    def test_is_tiered_help_mixin(self):
+        self.assertIsInstance(self.plugin, TieredHelpMixin)
+
+    def test_help_basic_returns_list(self):
+        result = self.plugin.help_basic()
+        self.assertIsInstance(result, list)
+        self.assertGreaterEqual(len(result), 1)
+        self.assertLessEqual(len(result), 2)
+
+    def test_help_full_returns_list(self):
+        result = self.plugin.help_full()
+        self.assertIsInstance(result, list)
+        self.assertGreaterEqual(len(result), 4)
+
+    def test_help_basic_messages_under_limit(self):
+        for msg in self.plugin.help_basic():
+            self.assertLessEqual(
+                len(msg),
+                MAX_APRS_MSG_LEN,
+                f'Message too long ({len(msg)} chars): {msg}',
+            )
+
+    def test_help_full_messages_under_limit(self):
+        for msg in self.plugin.help_full():
+            self.assertLessEqual(
+                len(msg),
+                MAX_APRS_MSG_LEN,
+                f'Message too long ({len(msg)} chars): {msg}',
+            )
+
+    def test_help_returns_help_basic(self):
+        self.assertEqual(self.plugin.help(), self.plugin.help_basic())
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+"""Tests for tiered help system."""
+
+import unittest
+
+from aprsd_repeat_plugins.help import MAX_APRS_MSG_LEN, TieredHelpMixin
+
+
+class MockPlugin(TieredHelpMixin):
+    """Mock plugin for testing mixin."""
+
+    command_name = 'mock'
+
+    def help_basic(self):
+        return ['mock: basic help']
+
+    def help_full(self):
+        return ['mock: full help line 1', 'mock: full help line 2']
+
+
+class TestTieredHelpMixin(unittest.TestCase):
+    def setUp(self):
+        self.plugin = MockPlugin()
+
+    def test_help_basic_returns_list(self):
+        result = self.plugin.help_basic()
+        self.assertIsInstance(result, list)
+        self.assertEqual(result, ['mock: basic help'])
+
+    def test_help_full_returns_list(self):
+        result = self.plugin.help_full()
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 2)
+
+    def test_help_returns_help_basic_for_backward_compat(self):
+        result = self.plugin.help()
+        self.assertEqual(result, self.plugin.help_basic())
+
+    def test_max_aprs_msg_len_constant(self):
+        self.assertEqual(MAX_APRS_MSG_LEN, 67)
+
+    def test_validate_help_messages_logs_warning_for_long_message(self):
+        """Test that _validate_help_messages logs warning for messages > 67 chars."""
+        long_msg = 'x' * 70  # 70 chars, exceeds 67 limit
+        with self.assertLogs('APRSD', level='WARNING') as log:
+            self.plugin._validate_help_messages([long_msg])
+        self.assertTrue(any('exceeds 67 chars' in msg for msg in log.output))
+
+    def test_validate_help_messages_no_warning_for_short_message(self):
+        """Test that _validate_help_messages does not warn for messages <= 67 chars."""
+        short_msg = 'x' * 67  # Exactly 67 chars, at limit
+        # Should not raise any warnings
+        result = self.plugin._validate_help_messages([short_msg])
+        self.assertEqual(result, [short_msg])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -284,5 +284,45 @@ class TestNearestObjectPluginHelp(unittest.TestCase):
         self.assertEqual(self.plugin.help(), self.plugin.help_basic())
 
 
+from aprsd_repeat_plugins.version import VersionPlugin
+
+
+class TestVersionPluginHelp(unittest.TestCase):
+    def setUp(self):
+        self.plugin = VersionPlugin()
+
+    def test_is_tiered_help_mixin(self):
+        self.assertIsInstance(self.plugin, TieredHelpMixin)
+
+    def test_help_basic_returns_list(self):
+        result = self.plugin.help_basic()
+        self.assertIsInstance(result, list)
+        self.assertGreaterEqual(len(result), 1)
+
+    def test_help_full_returns_list(self):
+        result = self.plugin.help_full()
+        self.assertIsInstance(result, list)
+        self.assertGreaterEqual(len(result), 1)
+
+    def test_help_basic_messages_under_limit(self):
+        for msg in self.plugin.help_basic():
+            self.assertLessEqual(
+                len(msg),
+                MAX_APRS_MSG_LEN,
+                f'Message too long ({len(msg)} chars): {msg}',
+            )
+
+    def test_help_full_messages_under_limit(self):
+        for msg in self.plugin.help_full():
+            self.assertLessEqual(
+                len(msg),
+                MAX_APRS_MSG_LEN,
+                f'Message too long ({len(msg)} chars): {msg}',
+            )
+
+    def test_help_returns_help_basic(self):
+        self.assertEqual(self.plugin.help(), self.plugin.help_basic())
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -9,6 +9,8 @@ from aprsd_repeat_plugins.help import (
     RepeatHelpPlugin,
     TieredHelpMixin,
 )
+from aprsd_repeat_plugins.nearest import NearestObjectPlugin, NearestPlugin
+from aprsd_repeat_plugins.version import VersionPlugin
 
 
 class MockPlugin(TieredHelpMixin):
@@ -205,9 +207,6 @@ class TestRepeatHelpPluginProcess(unittest.TestCase):
         self.assertEqual(result, 'No plugins available')
 
 
-from aprsd_repeat_plugins.nearest import NearestObjectPlugin, NearestPlugin
-
-
 class TestNearestPluginHelp(unittest.TestCase):
     def setUp(self):
         self.plugin = NearestPlugin()
@@ -284,9 +283,6 @@ class TestNearestObjectPluginHelp(unittest.TestCase):
         self.assertEqual(self.plugin.help(), self.plugin.help_basic())
 
 
-from aprsd_repeat_plugins.version import VersionPlugin
-
-
 class TestVersionPluginHelp(unittest.TestCase):
     def setUp(self):
         self.plugin = VersionPlugin()
@@ -322,6 +318,42 @@ class TestVersionPluginHelp(unittest.TestCase):
 
     def test_help_returns_help_basic(self):
         self.assertEqual(self.plugin.help(), self.plugin.help_basic())
+
+
+class TestHelpIntegration(unittest.TestCase):
+    """Integration tests for the full help flow."""
+
+    def test_all_basic_help_messages_under_limit(self):
+        """Verify all plugins have compliant basic help messages."""
+        plugins = [
+            NearestPlugin(),
+            NearestObjectPlugin(),
+            VersionPlugin(),
+            RepeatHelpPlugin(),
+        ]
+        for p in plugins:
+            for msg in p.help_basic():
+                self.assertLessEqual(
+                    len(msg),
+                    MAX_APRS_MSG_LEN,
+                    f'{p.command_name} basic help too long ({len(msg)}): {msg}',
+                )
+
+    def test_all_full_help_messages_under_limit(self):
+        """Verify all plugins have compliant full help messages."""
+        plugins = [
+            NearestPlugin(),
+            NearestObjectPlugin(),
+            VersionPlugin(),
+            RepeatHelpPlugin(),
+        ]
+        for p in plugins:
+            for msg in p.help_full():
+                self.assertLessEqual(
+                    len(msg),
+                    MAX_APRS_MSG_LEN,
+                    f'{p.command_name} full help too long ({len(msg)}): {msg}',
+                )
 
 
 if __name__ == '__main__':

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -91,34 +91,74 @@ class TestRepeatHelpPluginParsing(unittest.TestCase):
         self.plugin = RepeatHelpPlugin()
 
     def test_parse_help_alone(self):
-        cmd, plugin_name, is_full = self.plugin._parse_help_message('help')
-        self.assertEqual(cmd, 'help')
+        plugin_name, is_full = self.plugin._parse_help_message('help')
         self.assertIsNone(plugin_name)
         self.assertFalse(is_full)
 
     def test_parse_help_plugin(self):
-        cmd, plugin_name, is_full = self.plugin._parse_help_message('help nearest')
-        self.assertEqual(cmd, 'help')
+        plugin_name, is_full = self.plugin._parse_help_message('help nearest')
         self.assertEqual(plugin_name, 'nearest')
         self.assertFalse(is_full)
 
     def test_parse_help_plugin_full(self):
-        cmd, plugin_name, is_full = self.plugin._parse_help_message('help nearest full')
-        self.assertEqual(cmd, 'help')
+        plugin_name, is_full = self.plugin._parse_help_message('help nearest full')
         self.assertEqual(plugin_name, 'nearest')
         self.assertTrue(is_full)
 
     def test_parse_h_shorthand(self):
-        cmd, plugin_name, is_full = self.plugin._parse_help_message('h')
-        self.assertEqual(cmd, 'h')
+        plugin_name, is_full = self.plugin._parse_help_message('h')
         self.assertIsNone(plugin_name)
         self.assertFalse(is_full)
 
     def test_parse_h_plugin(self):
-        cmd, plugin_name, is_full = self.plugin._parse_help_message('h nearest')
-        self.assertEqual(cmd, 'h')
+        plugin_name, is_full = self.plugin._parse_help_message('h nearest')
         self.assertEqual(plugin_name, 'nearest')
         self.assertFalse(is_full)
+
+    # Issue 4: Tests for case variants, spaces, and extra tokens
+    def test_parse_uppercase_help(self):
+        """Test that 'HELP nearest full' parses correctly."""
+        plugin_name, is_full = self.plugin._parse_help_message('HELP nearest full')
+        self.assertEqual(plugin_name, 'nearest')
+        self.assertTrue(is_full)
+
+    def test_parse_mixed_case_help(self):
+        """Test that 'Help Nearest Full' parses correctly."""
+        plugin_name, is_full = self.plugin._parse_help_message('Help Nearest Full')
+        self.assertEqual(plugin_name, 'nearest')
+        self.assertTrue(is_full)
+
+    def test_parse_uppercase_full_flag(self):
+        """Test that 'help nearest FULL' parses correctly."""
+        plugin_name, is_full = self.plugin._parse_help_message('help nearest FULL')
+        self.assertEqual(plugin_name, 'nearest')
+        self.assertTrue(is_full)
+
+    def test_parse_leading_spaces(self):
+        """Test that leading spaces are handled."""
+        plugin_name, is_full = self.plugin._parse_help_message('  help nearest')
+        self.assertEqual(plugin_name, 'nearest')
+        self.assertFalse(is_full)
+
+    def test_parse_trailing_spaces(self):
+        """Test that trailing spaces are handled."""
+        plugin_name, is_full = self.plugin._parse_help_message('help nearest  ')
+        self.assertEqual(plugin_name, 'nearest')
+        self.assertFalse(is_full)
+
+    def test_parse_multiple_internal_spaces(self):
+        """Test that multiple internal spaces are handled."""
+        plugin_name, is_full = self.plugin._parse_help_message('help   nearest   full')
+        self.assertEqual(plugin_name, 'nearest')
+        self.assertTrue(is_full)
+
+    def test_parse_extra_tokens_after_full(self):
+        """Test that extra tokens after 'full' are ignored."""
+        plugin_name, is_full = self.plugin._parse_help_message(
+            'help nearest full extra stuff'
+        )
+        self.assertEqual(plugin_name, 'nearest')
+        self.assertTrue(is_full)
 
 
 class TestRepeatHelpPluginProcess(unittest.TestCase):
@@ -205,6 +245,102 @@ class TestRepeatHelpPluginProcess(unittest.TestCase):
             result = self.plugin.process(packet)
 
         self.assertEqual(result, 'No plugins available')
+
+    def test_process_unknown_plugin_no_plugins_returns_clean_error(self):
+        """Test that 'help unknown' with no plugins doesn't show 'Available: '."""
+        packet = MagicMock()
+        packet.message_text = 'help unknown'
+
+        with patch.object(self.plugin, '_get_repeat_plugins', return_value={}):
+            result = self.plugin.process(packet)
+
+        self.assertIn("Unknown plugin 'unknown'", result)
+        self.assertIn('No plugins available', result)
+        self.assertNotIn('Available: ', result)
+
+    # Issue 5: Tests for h/H shorthand and case-insensitive full in process()
+    def test_process_h_shorthand_lists_plugins(self):
+        """Test that 'h' shorthand lists available plugins."""
+        packet = MagicMock()
+        packet.message_text = 'h'
+
+        mock_nearest = MagicMock()
+        mock_nearest.command_name = 'nearest'
+
+        with patch.object(
+            self.plugin, '_get_repeat_plugins', return_value={'nearest': mock_nearest}
+        ):
+            result = self.plugin.process(packet)
+
+        self.assertIsInstance(result, list)
+        self.assertIn('plugins:', result[1])
+
+    def test_process_H_shorthand_lists_plugins(self):
+        """Test that 'H' shorthand lists available plugins."""
+        packet = MagicMock()
+        packet.message_text = 'H'
+
+        mock_nearest = MagicMock()
+        mock_nearest.command_name = 'nearest'
+
+        with patch.object(
+            self.plugin, '_get_repeat_plugins', return_value={'nearest': mock_nearest}
+        ):
+            result = self.plugin.process(packet)
+
+        self.assertIsInstance(result, list)
+        self.assertIn('plugins:', result[1])
+
+    def test_process_h_shorthand_with_plugin_returns_basic_help(self):
+        """Test that 'h nearest' returns basic help."""
+        packet = MagicMock()
+        packet.message_text = 'h nearest'
+
+        mock_nearest = MagicMock()
+        mock_nearest.command_name = 'nearest'
+        mock_nearest.help_basic.return_value = ['nearest basic help']
+
+        with patch.object(
+            self.plugin, '_get_repeat_plugins', return_value={'nearest': mock_nearest}
+        ):
+            result = self.plugin.process(packet)
+
+        mock_nearest.help_basic.assert_called_once()
+        self.assertEqual(result, ['nearest basic help'])
+
+    def test_process_case_insensitive_full_flag(self):
+        """Test that 'help nearest FULL' returns full help."""
+        packet = MagicMock()
+        packet.message_text = 'help nearest FULL'
+
+        mock_nearest = MagicMock()
+        mock_nearest.command_name = 'nearest'
+        mock_nearest.help_full.return_value = ['nearest full help']
+
+        with patch.object(
+            self.plugin, '_get_repeat_plugins', return_value={'nearest': mock_nearest}
+        ):
+            result = self.plugin.process(packet)
+
+        mock_nearest.help_full.assert_called_once()
+        self.assertEqual(result, ['nearest full help'])
+
+    def test_process_mixed_case_full_flag(self):
+        """Test that 'help nearest Full' returns full help."""
+        packet = MagicMock()
+        packet.message_text = 'help nearest Full'
+
+        mock_nearest = MagicMock()
+        mock_nearest.command_name = 'nearest'
+        mock_nearest.help_full.return_value = ['nearest full help']
+
+        with patch.object(
+            self.plugin, '_get_repeat_plugins', return_value={'nearest': mock_nearest}
+        ):
+            result = self.plugin.process(packet)
+
+        mock_nearest.help_full.assert_called_once()
+        self.assertEqual(result, ['nearest full help'])
 
 
 class TestNearestPluginHelp(unittest.TestCase):


### PR DESCRIPTION
## Summary

Implements a tiered help system for APRSD REPEAT plugins that balances informativeness with APRS message length constraints (~67 chars max).

- **Basic help** (`help <plugin>`): 1-2 short messages with syntax + options preview
- **Full help** (`help <plugin> full`): 4-8 messages with complete bands, filters, response format, and examples

## Changes

### New Files
- `aprsd_repeat_plugins/help.py` - `TieredHelpMixin` base class + `RepeatHelpPlugin`
- `tests/test_help.py` - 47 tests for the tiered help system

### Modified Files
- `aprsd_repeat_plugins/nearest.py` - Added tiered help to NearestPlugin and NearestObjectPlugin
- `aprsd_repeat_plugins/version.py` - Added tiered help to VersionPlugin
- `README.md` - Added Help System documentation section

## Usage

Users can now request help at two levels:

```
help nearest        → 2 short messages (syntax + preview)
help nearest full   → 7 messages (complete reference)
help object         → 2 short messages
help object full    → 5 messages
```

## Configuration

Enable `RepeatHelpPlugin` to use the tiered help system:

```yaml
aprsd:
  enabled_plugins:
    - aprsd_repeat_plugins.help.RepeatHelpPlugin
    - aprsd_repeat_plugins.nearest.NearestPlugin
    - aprsd_repeat_plugins.nearest.NearestObjectPlugin
    - aprsd_repeat_plugins.version.VersionPlugin
```

## Testing

- 47 tests added, all passing
- All help messages verified to be ≤67 characters (APRS limit)
- Integration tests ensure compliance across all plugins

## Summary by Sourcery

Introduce a tiered help system for APRSD REPEAT plugins with a shared mixin and dedicated help plugin, and wire it into existing plugins and documentation.

New Features:
- Add TieredHelpMixin and RepeatHelpPlugin to provide basic and full-tier help for REPEAT plugins over APRS.
- Extend NearestPlugin, NearestObjectPlugin, and VersionPlugin to expose concise and detailed help content via the tiered help system.

Enhancements:
- Ensure all help messages conform to APRS message length constraints and add integration coverage for help responses.
- Document the new tiered help system and configuration in the README.

Tests:
- Add a dedicated test suite for the tiered help mixin, RepeatHelpPlugin dispatch logic, plugin-specific help content, and APRS length limits across all help tiers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tiered help system: `help <plugin>` for basic help and `help <plugin> full` for detailed help; `help` lists available plugins or notes none exist.

* **Documentation**
  * README updated with tiered help workflow and configuration guidance to enable the new help provider and disable the legacy one.

* **Tests**
  * New unit tests covering help tiers, parsing, dispatch behavior, and message-length validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->