### PR TITLE
feat: pass command_type to haminfo /nearest API

### DIFF
--- a/aprsd_repeat_plugins/nearest.py
+++ b/aprsd_repeat_plugins/nearest.py
@@ -131,6 +131,7 @@ class NearestPlugin(
     version = aprsd_repeat_plugins.__version__
     command_regex = r'^([n]|[n]\s|nearest)'
     command_name = 'nearest'
+    command_type = 'nearest'
 
     def help_basic(self) -> list[str]:
         return [
@@ -315,6 +316,7 @@ class NearestPlugin(
                 'count': count,
                 'band': band,
                 'callsign': fromcall,
+                'command_type': self.command_type,
             }
             if filters:
                 params['filters'] = ','.join(filters)
@@ -401,6 +403,7 @@ class NearestObjectPlugin(NearestPlugin):
     version = aprsd_repeat_plugins.__version__
     command_regex = r'^([o]|[o]\s|object)'
     command_name = 'object'
+    command_type = 'object'
 
     def help_basic(self) -> list[str]:
         return [


### PR DESCRIPTION
## Problem

The haminfo REPEAT dashboard cannot distinguish between `n` (nearest) and `o` (object) commands because the plugin doesn't send the command type to the API.

## Changes

- Add `command_type` class attribute: `'nearest'` on `NearestPlugin`, `'object'` on `NearestObjectPlugin`
- Include `command_type` in the params dict sent to haminfo's `/nearest` endpoint

## Companion PR

- hemna/haminfo#37 adds the `command_type` column to the Request model and updates the dashboard display.

## Deployment Order

1. Deploy haminfo PR first (adds the column, ignores unknown params gracefully)
2. Deploy this plugin change second (starts sending `command_type`)

## Summary by Sourcery

Include the command type with nearest-related requests sent to the haminfo /nearest API so the dashboard can distinguish between nearest and object commands.

New Features:
- Add a command_type attribute to NearestPlugin and NearestObjectPlugin to identify nearest vs object commands.
- Send command_type as a parameter in requests to the haminfo /nearest endpoint to support improved dashboard reporting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved nearest-location command handling so standard and object-based searches are correctly distinguished.
  * Enhanced request processing for more accurate results from the nearest-location service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->